### PR TITLE
Add default size in SVG to prevent rendering problems in canvas

### DIFF
--- a/multiavatar.js
+++ b/multiavatar.js
@@ -495,7 +495,7 @@ function multiavatar (string, sansEnv, ver) {
 
 
   var sP = [];
-  var svgStart = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 231 231">';
+  var svgStart = '<svg xmlns="http://www.w3.org/2000/svg" width="231" height="231" viewBox="0 0 231 231">';
   var svgEnd = '</svg>';
 
   // Optimization


### PR DESCRIPTION
Hello,

I'm not sure if this PR is relevant but I've encountered a problem when I try to draw the generated SVG into a canvas (with some javascript like this) : 
```javascript
 window.addEventListener("load", function () {
            var myCanvas = document.querySelector('#myOutputCanvas')
            var ctx = myCanvas.getContext('2d')
            var img1 = new Image()
            img1.onload = function () {
                ctx.drawImage(img1, 0, 0)
            }
            var avatarId = 'Binx Bond';
// this doesn't work :
            var svgCode = multiavatar(avatarId);
// this works :
            svgCode = '<svg xmlns="http://www.w3.org/2000/svg" width="231" height="231" viewBox="0 0 231 231"><path .....'
            
            img1.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svgCode)
        })
```
When I copy-paste the content of the generated SVG and add the **height** and the **width** attributes into the svg root tag, it's ok.

I'm not an expert in SVG so if this PR would break other usages for your library, feel free to dismiss it.

Anyway, thank you for your time.